### PR TITLE
Add Cobra CLI with GitHub auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,17 @@ Build and run using Docker:
 ```bash
 docker build -t eskimo .
 
-docker run -e GITHUB_TOKEN=xxxx -v $HOME/.config:/root/.config eskimo -org my-org
+docker run -e GITHUB_TOKEN=xxxx -v $HOME/.config:/root/.config eskimo --org my-org
 ```
 
 ## Usage
 
 ```bash
 go build
-./eskimo -org my-org -config scanners.yaml
+./eskimo --org my-org --config scanners.yaml
+
+# To obtain a token using GitHub's device flow run:
+eskimo auth --org my-org
 ```
 
 Repositories are cloned under `/tmp/github-repos`. If a repository directory

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ go build
 
 # To obtain a token using GitHub's device flow run:
 eskimo auth --org my-org
+# The command prints a code and opens a browser for authorization
 ```
 
 Repositories are cloned under `/tmp/github-repos`. If a repository directory

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"eskimo/internal/auth"
+
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ var authCmd = &cobra.Command{
 		if clientID == "" {
 			return fmt.Errorf("GITHUB_CLIENT_ID must be set")
 		}
+
 		token, err := auth.DeviceFlow(cmd.Context(), clientID, "repo", auth.DefaultBrowser, cmd.OutOrStdout())
 		if err != nil {
 			return err
@@ -28,7 +30,7 @@ var authCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Token saved to %s\n", path)
+		fmt.Fprintf(cmd.OutOrStdout(), "Authorization is successful. Token saved to %s\n", path)
 		return nil
 	},
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"eskimo/internal/auth"
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Authorize via GitHub device flow",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if org == "" {
+			return errors.New("--org required")
+		}
+		clientID := os.Getenv("GITHUB_CLIENT_ID")
+		if clientID == "" {
+			return fmt.Errorf("GITHUB_CLIENT_ID must be set")
+		}
+		token, err := auth.DeviceFlow(cmd.Context(), clientID, "repo", auth.DefaultBrowser)
+		if err != nil {
+			return err
+		}
+		path, err := auth.SaveToken(token)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Token saved to %s\n", path)
+		return nil
+	},
+}
+
+func init() {
+	authCmd.Flags().StringVar(&org, "org", "", "GitHub organization")
+	authCmd.MarkFlagRequired("org")
+}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -20,7 +20,7 @@ var authCmd = &cobra.Command{
 		if clientID == "" {
 			return fmt.Errorf("GITHUB_CLIENT_ID must be set")
 		}
-		token, err := auth.DeviceFlow(cmd.Context(), clientID, "repo", auth.DefaultBrowser)
+		token, err := auth.DeviceFlow(cmd.Context(), clientID, "repo", auth.DefaultBrowser, cmd.OutOrStdout())
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"eskimo/internal/auth"
+	"eskimo/internal/config"
+	internalgithub "eskimo/internal/github"
+	"eskimo/internal/scanner"
+)
+
+var (
+	org        string
+	configPath string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "eskimo",
+	Short: "Pluggable security scanner",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token := auth.LoadToken()
+		if token == "" {
+			return fmt.Errorf("GITHUB_TOKEN must be set or run 'eskimo auth'")
+		}
+		cfg, err := config.Load(configPath)
+		if err != nil {
+			return err
+		}
+		gh := internalgithub.NewClient(token, org)
+		ctx := context.Background()
+		repos, err := gh.ListRepos(ctx)
+		if err != nil {
+			return err
+		}
+		baseDir := filepath.Join("/tmp", "github-repos")
+		os.MkdirAll(baseDir, 0755)
+		fmt.Printf("found %d repositories\n", len(repos))
+		for i, repo := range repos {
+			fmt.Printf("[%d/%d] cloning %s...\n", i+1, len(repos), repo.GetName())
+			repoPath, err := gh.CloneRepo(repo, baseDir)
+			if err != nil {
+				log.Printf("failed to clone %s: %v", repo.GetName(), err)
+				continue
+			}
+			for _, sc := range cfg.Scanners {
+				s := scanner.Scanner(sc)
+				fmt.Printf("  running %s...\n", sc.Name)
+				if err := s.Run(ctx, repoPath); err != nil {
+					log.Printf("scanner %s failed on %s: %v", sc.Name, repo.GetName(), err)
+				}
+			}
+		}
+		return nil
+	},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&org, "org", "", "GitHub organization")
+	rootCmd.PersistentFlags().StringVar(&configPath, "config", "scanners.yaml", "Scanner config file")
+	rootCmd.MarkPersistentFlagRequired("org")
+	rootCmd.AddCommand(authCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.8
 
 require (
 	github.com/google/go-github/v55 v55.0.0
+	github.com/spf13/cobra v1.8.0
 	golang.org/x/oauth2 v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -12,6 +13,8 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -11,6 +12,13 @@ github.com/google/go-github/v55 v55.0.0 h1:4pp/1tNMB9X/LuAhs5i0KQAE40NmiR/y6prLN
 github.com/google/go-github/v55 v55.0.0/go.mod h1:JLahOTA1DnXzhxEymmFF5PP2tSS9JVNj68mSZNDwskA=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,144 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type deviceCodeResp struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+type tokenResp struct {
+	AccessToken string `json:"access_token"`
+	Error       string `json:"error"`
+}
+
+var (
+	deviceEndpoint = "https://github.com/login/device/code"
+	tokenEndpoint  = "https://github.com/login/oauth/access_token"
+)
+
+// DeviceFlow performs GitHub device authorization flow.
+// openBrowser is called with the verification URL to open for user login.
+func DeviceFlow(ctx context.Context, clientID, scope string, openBrowser func(string) error) (string, error) {
+	values := url.Values{}
+	values.Set("client_id", clientID)
+	values.Set("scope", scope)
+	resp, err := http.PostForm(deviceEndpoint, values)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var dc deviceCodeResp
+	if err := json.NewDecoder(resp.Body).Decode(&dc); err != nil {
+		return "", err
+	}
+	verURL := dc.VerificationURIComplete
+	if verURL == "" {
+		verURL = dc.VerificationURI
+	}
+	if openBrowser != nil {
+		openBrowser(verURL)
+	}
+	ticker := time.NewTicker(time.Duration(dc.Interval) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+			v := url.Values{}
+			v.Set("client_id", clientID)
+			v.Set("device_code", dc.DeviceCode)
+			v.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(v.Encode()))
+			if err != nil {
+				return "", err
+			}
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			r, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return "", err
+			}
+			var tr tokenResp
+			if err := json.NewDecoder(r.Body).Decode(&tr); err != nil {
+				r.Body.Close()
+				return "", err
+			}
+			r.Body.Close()
+			if tr.AccessToken != "" {
+				return tr.AccessToken, nil
+			}
+			switch tr.Error {
+			case "authorization_pending":
+				continue
+			case "slow_down":
+				ticker.Reset(time.Duration(dc.Interval+5) * time.Second)
+			default:
+				return "", fmt.Errorf("authorization failed: %s", tr.Error)
+			}
+		}
+	}
+}
+
+// SaveToken stores the token in ~/.config/eskimo/token with 0600 permissions.
+func SaveToken(token string) (string, error) {
+	dir := filepath.Join(os.Getenv("HOME"), ".config", "eskimo")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte(token), 0600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// LoadToken returns GITHUB_TOKEN environment variable or stored token if present.
+func LoadToken() string {
+	if t := os.Getenv("GITHUB_TOKEN"); t != "" {
+		return t
+	}
+	path := filepath.Join(os.Getenv("HOME"), ".config", "eskimo", "token")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// DefaultBrowser attempts to open a URL in the default browser.
+func DefaultBrowser(url string) error {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	case "windows":
+		cmd = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler"}
+	default:
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return execCommand(cmd, args...)
+}
+
+var execCommand = func(name string, args ...string) error {
+	return exec.Command(name, args...).Start()
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -35,7 +36,7 @@ var (
 
 // DeviceFlow performs GitHub device authorization flow.
 // openBrowser is called with the verification URL to open for user login.
-func DeviceFlow(ctx context.Context, clientID, scope string, openBrowser func(string) error) (string, error) {
+func DeviceFlow(ctx context.Context, clientID, scope string, openBrowser func(string) error, out io.Writer) (string, error) {
 	values := url.Values{}
 	values.Set("client_id", clientID)
 	values.Set("scope", scope)
@@ -57,6 +58,13 @@ func DeviceFlow(ctx context.Context, clientID, scope string, openBrowser func(st
 	verURL := dc.VerificationURIComplete
 	if verURL == "" {
 		verURL = dc.VerificationURI
+	}
+	if out != nil {
+		fmt.Fprintf(out, "\nTo authorize Eskimo, visit:\n%s\n\nand enter the code: %s\n\n", verURL, dc.UserCode)
+		if openBrowser != nil {
+			fmt.Fprintln(out, "A browser window has been opened. If it didn't open, use the URL above.")
+		}
+		fmt.Fprintln(out, "Waiting for authorization...")
 	}
 	if openBrowser != nil {
 		openBrowser(verURL)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -39,7 +39,13 @@ func DeviceFlow(ctx context.Context, clientID, scope string, openBrowser func(st
 	values := url.Values{}
 	values.Set("client_id", clientID)
 	values.Set("scope", scope)
-	resp, err := http.PostForm(deviceEndpoint, values)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, deviceEndpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -71,6 +77,7 @@ func DeviceFlow(ctx context.Context, clientID, scope string, openBrowser func(st
 				return "", err
 			}
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Accept", "application/json")
 			r, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return "", err

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -15,6 +15,9 @@ import (
 func TestDeviceFlow(t *testing.T) {
 	deviceCh := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "application/json" {
+			t.Errorf("Accept header not set")
+		}
 		switch r.URL.Path {
 		case "/login/device/code":
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -45,9 +46,10 @@ func TestDeviceFlow(t *testing.T) {
 
 	opened := false
 	openFunc := func(url string) error { opened = true; return nil }
+	var buf bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	tok, err := DeviceFlow(ctx, "client", "repo", openFunc)
+	tok, err := DeviceFlow(ctx, "client", "repo", openFunc, &buf)
 	if err != nil {
 		t.Fatalf("flow failed: %v", err)
 	}
@@ -56,6 +58,10 @@ func TestDeviceFlow(t *testing.T) {
 	}
 	if !opened {
 		t.Fatalf("browser not opened")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "enter the code: u") {
+		t.Fatalf("output missing code: %q", out)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeviceFlow(t *testing.T) {
+	deviceCh := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/device/code":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"device_code":"code","user_code":"u","verification_uri":"https://example.com","interval":1}`))
+		case "/login/oauth/access_token":
+			body, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(body), "device_code=code") {
+				if len(deviceCh) == 0 {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"error":"authorization_pending"}`))
+					deviceCh <- struct{}{}
+				} else {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"access_token":"tok"}`))
+				}
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	deviceEndpoint = server.URL + "/login/device/code"
+	tokenEndpoint = server.URL + "/login/oauth/access_token"
+
+	opened := false
+	openFunc := func(url string) error { opened = true; return nil }
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tok, err := DeviceFlow(ctx, "client", "repo", openFunc)
+	if err != nil {
+		t.Fatalf("flow failed: %v", err)
+	}
+	if tok != "tok" {
+		t.Fatalf("unexpected token: %s", tok)
+	}
+	if !opened {
+		t.Fatalf("browser not opened")
+	}
+}
+
+func TestSaveLoadToken(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	path, err := SaveToken("secret")
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if path != filepath.Join(tmp, ".config", "eskimo", "token") {
+		t.Fatalf("unexpected path: %s", path)
+	}
+	tok := LoadToken()
+	if tok != "secret" {
+		t.Fatalf("expected token, got %s", tok)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,62 +1,12 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
-	"log"
+	"eskimo/cmd"
 	"os"
-	"path/filepath"
-
-	"eskimo/internal/config"
-	internalgithub "eskimo/internal/github"
-	"eskimo/internal/scanner"
 )
 
 func main() {
-	var org string
-	var configPath string
-	flag.StringVar(&org, "org", "", "GitHub organization")
-	flag.StringVar(&configPath, "config", "scanners.yaml", "Scanner config file")
-	flag.Parse()
-
-	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
-		log.Fatal("GITHUB_TOKEN must be set")
-	}
-	if org == "" {
-		log.Fatal("-org must be specified")
-	}
-
-	cfg, err := config.Load(configPath)
-	if err != nil {
-		log.Fatalf("loading config: %v", err)
-	}
-
-	gh := internalgithub.NewClient(token, org)
-	ctx := context.Background()
-	repos, err := gh.ListRepos(ctx)
-	if err != nil {
-		log.Fatalf("listing repos: %v", err)
-	}
-
-	baseDir := filepath.Join("/tmp", "github-repos")
-	os.MkdirAll(baseDir, 0755)
-
-	fmt.Printf("found %d repositories\n", len(repos))
-	for i, repo := range repos {
-		fmt.Printf("[%d/%d] cloning %s...\n", i+1, len(repos), repo.GetName())
-		repoPath, err := gh.CloneRepo(repo, baseDir)
-		if err != nil {
-			log.Printf("failed to clone %s: %v", repo.GetName(), err)
-			continue
-		}
-		for _, sc := range cfg.Scanners {
-			s := scanner.Scanner(sc)
-			fmt.Printf("  running %s...\n", sc.Name)
-			if err := s.Run(ctx, repoPath); err != nil {
-				log.Printf("scanner %s failed on %s: %v", sc.Name, repo.GetName(), err)
-			}
-		}
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
 	}
 }

--- a/scanners.yaml
+++ b/scanners.yaml
@@ -3,15 +3,22 @@
 # Pass environment variables for scanner to pick from env: [] list
 
 scanners:
+  # Enterprise scanners
   - name: semgrep
     command: ["semgrep", "scan"]
     env: ["SEMGREP_PAT_TOKEN"]
-    disable: false
   - name: wiz
     pre_command: ["wizcli", "auth"]
     command: ["wizcli", "dir", "scan"]
     env: ["WIZ_CLIENT_ID", "WIZ_CLIENT_SECRET"]
     disable: true
+  - name: cycode
+    pre_command: ["cycode", "auth"]
+    command: ["cycode", "scan", "path", "."]
+    env: ["CYCODE_CLIENT_ID", "CYCODE_CLIENT_SECRET"]
+    disable: true
+
+  # OSS scanners
   - name: scharf
     command: ["scharf", "audit"]
     env: []


### PR DESCRIPTION
## Summary
- switch CLI to Cobra and rename flags to `--org` and `--config`
- add `eskimo auth --org` command implementing GitHub device flow
- store retrieved token securely in `~/.config/eskimo/token`
- load token from file when scanning
- document new commands
- add unit tests for the authentication helpers

## Testing
- `go test ./...`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860a800de648332a2acd9c3c7a05129