### PR TITLE
Add AWS terraform automation for weekly scans

### DIFF
--- a/docs/adr/0002-aws-infra.md
+++ b/docs/adr/0002-aws-infra.md
@@ -1,0 +1,15 @@
+# 2. AWS Infrastructure for Scheduled Scans
+
+## Status
+Accepted
+
+## Context
+Eskimo needs to run weekly security scans without manual intervention. Deploying the scanner as a container on AWS Fargate keeps operations simple while leveraging managed services like CloudWatch Events and Secrets Manager.
+
+## Decision
+We provision an ECS Fargate cluster and a task definition that runs the container built from this repository. A CloudWatch Event rule triggers `ecs:RunTask` on a cron schedule every Monday. Secrets required by the scanner (GitHub token and Wiz credentials) are stored in AWS Secrets Manager and passed to the task. Terraform state is kept in an S3 bucket with locking in DynamoDB. Network resources, the ECS cluster, and the ECR repository are created via community Terraform modules.
+
+## Consequences
+- Scans run automatically each week with logs stored in CloudWatch.
+- Using Fargate means tasks stop after completion, so there is no compute cost outside of scan runs.
+- The infrastructure can be recreated consistently from Terraform state.

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,192 @@
+# VPC for Fargate tasks
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "eskimo-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs            = ["us-east-1a", "us-east-1b"]
+  public_subnets = ["10.0.0.0/24", "10.0.1.0/24"]
+
+  enable_nat_gateway = false
+  single_nat_gateway = false
+  enable_vpn_gateway = false
+}
+
+# ECS Cluster
+module "ecs_cluster" {
+  source  = "terraform-aws-modules/ecs/aws//modules/cluster"
+  version = "~> 5.0"
+
+  cluster_name = var.cluster_name
+}
+
+# ECR Repository for the scanner image
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  version = "~> 1.5"
+
+  repository_name = "eskimo"
+}
+
+# Secrets Manager
+resource "aws_secretsmanager_secret" "scanner" {
+  name = var.secret_name
+}
+
+resource "aws_secretsmanager_secret_version" "scanner" {
+  secret_id     = aws_secretsmanager_secret.scanner.id
+  secret_string = jsonencode(var.secret_values)
+}
+
+# IAM role for ECS task execution
+data "aws_iam_policy_document" "task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_exec" {
+  name               = "eskimo-task-exec"
+  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_exec" {
+  role       = aws_iam_role.task_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow task to read secrets
+data "aws_iam_policy_document" "secret_access" {
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.scanner.arn]
+  }
+}
+
+resource "aws_iam_policy" "secret_access" {
+  name   = "eskimo-secret-access"
+  policy = data.aws_iam_policy_document.secret_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "secret_access" {
+  role       = aws_iam_role.task_exec.name
+  policy_arn = aws_iam_policy.secret_access.arn
+}
+
+# CloudWatch Log Group
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/eskimo"
+  retention_in_days = 30
+}
+
+# ECS Task Definition
+locals {
+  image = "${module.ecr.repository_url}:latest"
+}
+
+resource "aws_ecs_task_definition" "scan" {
+  family                   = "eskimo-scan"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.task_exec.arn
+  task_role_arn            = aws_iam_role.task_exec.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "eskimo"
+      image     = local.image
+      essential = true
+      command   = ["--org", var.github_org, "--config", "/app/scanners.yaml"]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "eskimo"
+        }
+      }
+      secrets = [
+        { name = "GITHUB_TOKEN", valueFrom = "${aws_secretsmanager_secret.scanner.arn}:GITHUB_TOKEN::" },
+        { name = "WIZ_CLIENT_ID", valueFrom = "${aws_secretsmanager_secret.scanner.arn}:WIZ_CLIENT_ID::" },
+        { name = "WIZ_CLIENT_SECRET", valueFrom = "${aws_secretsmanager_secret.scanner.arn}:WIZ_CLIENT_SECRET::" }
+      ]
+    }
+  ])
+}
+
+# Security group for tasks
+resource "aws_security_group" "ecs_tasks" {
+  name_prefix = "ecs-tasks-"
+  vpc_id      = module.vpc.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# CloudWatch Event rule to trigger weekly
+resource "aws_cloudwatch_event_rule" "weekly" {
+  name                = "eskimo-weekly"
+  schedule_expression = "cron(0 0 ? * MON *)"
+}
+
+# IAM role for EventBridge to run tasks
+data "aws_iam_policy_document" "event_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "event" {
+  name               = "ecs-scan-event"
+  assume_role_policy = data.aws_iam_policy_document.event_assume.json
+}
+
+data "aws_iam_policy_document" "event" {
+  statement {
+    actions   = ["ecs:RunTask"]
+    resources = [aws_ecs_task_definition.scan.arn]
+  }
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.task_exec.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "event" {
+  role   = aws_iam_role.event.id
+  policy = data.aws_iam_policy_document.event.json
+}
+
+resource "aws_cloudwatch_event_target" "ecs" {
+  rule      = aws_cloudwatch_event_rule.weekly.name
+  target_id = "EcsTask"
+  arn       = module.ecs_cluster.arn
+  role_arn  = aws_iam_role.event.arn
+
+  ecs_target {
+    task_definition_arn = aws_ecs_task_definition.scan.arn
+    launch_type         = "FARGATE"
+    network_configuration {
+      subnets          = module.vpc.public_subnets
+      security_groups  = [aws_security_group.ecs_tasks.id]
+      assign_public_ip = true
+    }
+    platform_version = "LATEST"
+  }
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,28 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+  default     = "eskimo-scanner"
+}
+
+variable "github_org" {
+  description = "GitHub organization to scan"
+  type        = string
+}
+
+variable "secret_name" {
+  description = "Secrets Manager secret name"
+  type        = string
+  default     = "eskimo-config"
+}
+
+variable "secret_values" {
+  description = "Key-value map for scanner configuration"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/aws/versions.tf
+++ b/terraform/aws/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "eskimo-tf-state"
+    key            = "eksimo/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "eskimo-tf-lock"
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,29 @@
+module "state_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 4.0"
+
+  bucket = var.state_bucket_name
+
+  versioning = {
+    enabled = true
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_dynamodb_table" "tf_lock" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -1,0 +1,16 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "state_bucket_name" {
+  description = "Name of S3 bucket for Terraform state"
+  type        = string
+}
+
+variable "lock_table_name" {
+  description = "DynamoDB table for Terraform state locking"
+  type        = string
+  default     = "terraform-lock"
+}

--- a/terraform/bootstrap/versions.tf
+++ b/terraform/bootstrap/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
## Summary
- add Terraform infrastructure to run Eskimo scanner on AWS
- create bootstrap configs for remote state
- document architecture decision for AWS deployment

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: errcheck, staticcheck)*
- `govulncheck ./...`

------
https://chatgpt.com/codex/tasks/task_e_6861c5b15ec08332b9f025c69097817f