### PR TITLE
Add manual EventBridge trigger

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,13 @@
+# Terraform
+
+This directory holds the infrastructure to run Eskimo in AWS environment. Once `bootstrap` and `aws` are created,
+one can trigger the scanner using AWS CLI:
+
+```sh
+aws events put-events \
+  --entries '[{
+    "Source":"eskimo.manual",
+    "DetailType":"manual trigger",
+    "Detail":"{}"
+  }]'
+```

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -212,3 +212,29 @@ resource "aws_cloudwatch_event_target" "ecs" {
     platform_version = "LATEST"
   }
 }
+
+# CloudWatch Event rule for manual trigger
+resource "aws_cloudwatch_event_rule" "manual" {
+  name          = "eskimo-manual"
+  event_pattern = jsonencode({
+    source = ["eskimo.manual"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "manual" {
+  rule      = aws_cloudwatch_event_rule.manual.name
+  target_id = "ManualEcsTask"
+  arn       = module.ecs_cluster.arn
+  role_arn  = aws_iam_role.event.arn
+
+  ecs_target {
+    task_definition_arn = aws_ecs_task_definition.scan.arn
+    launch_type         = "FARGATE"
+    network_configuration {
+      subnets          = module.vpc.public_subnets
+      security_groups  = [aws_security_group.ecs_tasks.id]
+      assign_public_ip = true
+    }
+    platform_version = "LATEST"
+  }
+}


### PR DESCRIPTION
## Summary
- add new CloudWatch rule and target to allow manual ECS task runs

## Testing
- `go test ./...`
- `go vet ./...`
- `govulncheck ./...`

------
https://chatgpt.com/codex/tasks/task_e_6861eb60c6ec833292c6e5082f384132