### PR TITLE
Use immutable image digests

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -25,10 +25,16 @@ jobs:
           aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 525500656121.dkr.ecr.us-west-2.amazonaws.com
 
       - name: Build image
-        run: docker build -t eskimo .
-
-      - name: Tag image
-        run: docker tag eskimo:latest 525500656121.dkr.ecr.us-west-2.amazonaws.com/eskimo:latest
+        run: |
+          IMAGE_URI=525500656121.dkr.ecr.us-west-2.amazonaws.com/eskimo
+          docker build -t $IMAGE_URI:${{ github.sha }} .
+          docker tag $IMAGE_URI:${{ github.sha }} $IMAGE_URI:latest
 
       - name: Push image
-        run: docker push 525500656121.dkr.ecr.us-west-2.amazonaws.com/eskimo:latest
+        id: push
+        run: |
+          IMAGE_URI=525500656121.dkr.ecr.us-west-2.amazonaws.com/eskimo
+          docker push $IMAGE_URI:${{ github.sha }}
+          docker push $IMAGE_URI:latest
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE_URI:${{ github.sha }})
+          echo "digest=${DIGEST##*@}" >> "$GITHUB_OUTPUT"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -140,9 +140,15 @@ resource "aws_cloudwatch_log_group" "ecs" {
   retention_in_days = 30
 }
 
+# Latest image digest
+data "aws_ecr_image" "latest" {
+  repository_name = module.ecr.repository_name
+  image_tag       = "latest"
+}
+
 # ECS Task Definition
 locals {
-  image = "${module.ecr.repository_url}:latest"
+  image = "${module.ecr.repository_url}@${data.aws_ecr_image.latest.image_digest}"
 }
 
 resource "aws_ecs_task_definition" "scan" {
@@ -248,7 +254,7 @@ resource "aws_cloudwatch_event_target" "ecs" {
 
 # CloudWatch Event rule for manual trigger
 resource "aws_cloudwatch_event_rule" "manual" {
-  name          = "eskimo-manual"
+  name = "eskimo-manual"
   event_pattern = jsonencode({
     source = ["eskimo.manual"]
   })


### PR DESCRIPTION
## Summary
- push Docker images using commit SHA and capture the resulting digest
- update Terraform to resolve the `latest` image digest and use it for the ECS task definition

## Testing
- `go vet ./...`
- `govulncheck ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6862125fe21c8332a817575b383afce7