### PR TITLE
Improve scan performance with goroutines

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
+
+	github "github.com/google/go-github/v55/github"
 
 	"github.com/spf13/cobra"
 
@@ -41,21 +45,60 @@ var rootCmd = &cobra.Command{
 		baseDir := filepath.Join("/tmp", "github-repos")
 		os.MkdirAll(baseDir, 0755)
 		fmt.Printf("found %d repositories\n", len(repos))
-		for i, repo := range repos {
-			fmt.Printf("[%d/%d] cloning %s...\n", i+1, len(repos), repo.GetName())
-			repoPath, err := gh.CloneRepo(repo, baseDir)
-			if err != nil {
-				log.Printf("failed to clone %s: %v", repo.GetName(), err)
-				continue
-			}
-			for _, sc := range cfg.Scanners {
-				s := scanner.Scanner(sc)
-				fmt.Printf("  running %s...\n", sc.Name)
-				if err := s.Run(ctx, repoPath); err != nil {
-					log.Printf("scanner %s failed on %s: %v", sc.Name, repo.GetName(), err)
-				}
-			}
+
+		parallel := runtime.NumCPU()
+		sem := make(chan struct{}, parallel)
+		type repoInfo struct {
+			name string
+			path string
 		}
+		repoCh := make(chan repoInfo, len(repos))
+		var cloneWG sync.WaitGroup
+		for _, repo := range repos {
+			cloneWG.Add(1)
+			sem <- struct{}{}
+			go func(r *github.Repository) {
+				defer cloneWG.Done()
+				fmt.Printf("cloning %s...\n", r.GetName())
+				repoPath, err := gh.CloneRepo(r, baseDir)
+				if err != nil {
+					log.Printf("failed to clone %s: %v", r.GetName(), err)
+					<-sem
+					return
+				}
+				repoCh <- repoInfo{name: r.GetName(), path: repoPath}
+				<-sem
+			}(repo)
+		}
+		cloneWG.Wait()
+		close(repoCh)
+
+		scanSem := make(chan struct{}, parallel)
+		var scanWG sync.WaitGroup
+		for info := range repoCh {
+			scanWG.Add(1)
+			scanSem <- struct{}{}
+			go func(in repoInfo) {
+				defer scanWG.Done()
+				var wg sync.WaitGroup
+				for _, sc := range cfg.Scanners {
+					scCopy := sc
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						s := scanner.Scanner(scCopy)
+						fmt.Printf("%s: running %s...\n", in.name, scCopy.Name)
+						if err := s.Run(ctx, in.path); err != nil {
+							log.Printf("scanner %s failed on %s: %v", scCopy.Name, in.name, err)
+						}
+					}()
+				}
+				wg.Wait()
+				<-scanSem
+			}(info)
+		}
+		scanWG.Wait()
+
 		return nil
 	},
 }

--- a/docs/adr/0004-parallel-scanning.md
+++ b/docs/adr/0004-parallel-scanning.md
@@ -1,0 +1,20 @@
+# 4. Parallel Scanning Implementation
+
+## Status
+Accepted
+
+## Context
+Originally Eskimo cloned repositories and ran each configured scanner sequentially. This kept the code simple but made scans slow when organisations contain many repositories.
+
+## Decision
+We introduced concurrency to utilise all available CPU cores:
+
+- Repositories are cloned in parallel using a worker pool limited by `runtime.NumCPU()`.
+- After cloning completes, another pool scans repositories concurrently.
+- Each repository run spawns goroutines for each enabled scanner.
+
+This design keeps the code relatively small while significantly reducing overall scan time.
+
+## Consequences
+- Scan duration now scales with the number of available CPU cores.
+- Output may interleave across goroutines, but failures are still logged per repository and scanner.

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -57,3 +57,41 @@ func TestCloneRepo_UpdateExisting(t *testing.T) {
 		t.Fatalf("file not pulled: %v", err)
 	}
 }
+
+func TestCloneRepo_ReplaceNonGitDir(t *testing.T) {
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "remote")
+	if err := os.Mkdir(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(dir string, args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", err, out)
+		}
+	}
+	run(repoDir, "init")
+	os.WriteFile(filepath.Join(repoDir, "a.txt"), []byte("hello"), 0644)
+	run(repoDir, "add", "a.txt")
+	run(repoDir, "commit", "-m", "init")
+
+	base := filepath.Join(tmp, "repos")
+	os.Mkdir(base, 0755)
+	dest := filepath.Join(base, "remote")
+	os.Mkdir(dest, 0755)
+	os.WriteFile(filepath.Join(dest, "junk"), []byte("x"), 0644)
+
+	repo := &gh.Repository{Name: gh.String("remote"), CloneURL: gh.String(repoDir)}
+	c := &Client{}
+	path, err := c.CloneRepo(repo, base)
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	if path != dest {
+		t.Fatalf("expected %s, got %s", dest, path)
+	}
+	if _, err := os.Stat(filepath.Join(path, ".git")); err != nil {
+		t.Fatalf("repo not cloned: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add parallel clone and scan workers
- document the parallel scanning design

## Testing
- `go vet ./...`
- `/root/go/bin/govulncheck ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6868aa96b9c48332a939eb4ee3e60546