### PR TITLE
Improve Terraform security posture

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -85,12 +85,8 @@ resource "aws_iam_role_policy_attachment" "github_ecr" {
 # Secrets Manager
 data "aws_iam_policy_document" "kms" {
   statement {
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey"
-    ]
+    sid       = "EnableRoot"
+    actions   = ["kms:*"]
     principals {
       type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
@@ -101,8 +97,8 @@ data "aws_iam_policy_document" "kms" {
 
 resource "aws_kms_key" "secrets" {
   description         = "Key for secrets and logs"
-  policy              = data.aws_iam_policy_document.kms.json
   enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.kms.json
 }
 
 resource "aws_secretsmanager_secret" "scanner" {

--- a/terraform/aws/rotate.py
+++ b/terraform/aws/rotate.py
@@ -1,0 +1,3 @@
+def handler(event, context):
+    """Placeholder rotation function."""
+    return {}

--- a/terraform/aws/versions.tf
+++ b/terraform/aws/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
   }
 
   backend "s3" {

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,3 +1,16 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "kms" {
+  statement {
+    actions   = ["kms:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    resources = ["*"]
+  }
+}
+
 module "state_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 4.0"
@@ -17,10 +30,25 @@ module "state_bucket" {
   }
 }
 
+resource "aws_kms_key" "dynamo" {
+  description         = "Key for DynamoDB tables"
+  policy              = data.aws_iam_policy_document.kms.json
+  enable_key_rotation = true
+}
+
 resource "aws_dynamodb_table" "infra_tf_lock" {
   name         = var.infra_lock_table_name
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "LockID"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.dynamo.arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
 
   attribute {
     name = "LockID"
@@ -32,6 +60,15 @@ resource "aws_dynamodb_table" "bootstrap_tf_lock" {
   name         = var.bootstrap_lock_table_name
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "LockID"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.dynamo.arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
 
   attribute {
     name = "LockID"

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -3,11 +3,26 @@ data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "kms" {
   statement {
-    sid       = "EnableRoot"
-    actions   = ["kms:*"]
+    sid     = "EnableRoot"
+    actions = ["kms:*"]
     principals {
       type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    resources = ["arn:aws:kms:${var.region}:${data.aws_caller_identity.current.account_id}:key/*"]
+  }
+  statement {
+    sid    = "AllowDynamo"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["dynamodb.${var.region}.amazonaws.com"]
     }
     resources = ["arn:aws:kms:${var.region}:${data.aws_caller_identity.current.account_id}:key/*"]
   }

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -3,12 +3,8 @@ data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "kms" {
   statement {
-    actions = [
-      "kms:Encrypt",
-      "kms:Decrypt",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey"
-    ]
+    sid       = "EnableRoot"
+    actions   = ["kms:*"]
     principals {
       type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
@@ -16,6 +12,7 @@ data "aws_iam_policy_document" "kms" {
     resources = ["arn:aws:kms:${var.region}:${data.aws_caller_identity.current.account_id}:key/*"]
   }
 }
+
 
 module "state_bucket" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=e1fb51bce8008b0d5fd660e81d97ff7a101bdbc6"


### PR DESCRIPTION
## Summary
- encrypt Secrets Manager with KMS and rotate key
- secure CloudWatch log group
- enforce read-only root filesystem
- describe ECS security group and restrict egress
- enable encryption/PITR for DynamoDB state tables

## Testing
- `go test ./...`
- `tflint --chdir=terraform`
- `tfsec terraform`
- `checkov --directory terraform`


------
https://chatgpt.com/codex/tasks/task_e_6869a9f0e9348332a8773d050c8eb6d9