### PR TITLE
Add logging bucket for Terraform state

### DIFF
--- a/docs/Runbooks/aws-deploy.md
+++ b/docs/Runbooks/aws-deploy.md
@@ -28,6 +28,7 @@ terraform apply
 After this step you will have:
 
 - `eskimo-tf-state` S3 bucket
+- `eskimo-tf-logs` S3 bucket for state bucket access logs
 - `eskimo-infra-tf-lock` DynamoDB table
 - `eskimo-bootstrap-tf-lock` DynamoDB table
 

--- a/docs/adr/0005-s3-state-logging.md
+++ b/docs/adr/0005-s3-state-logging.md
@@ -1,0 +1,14 @@
+# 5. S3 Bucket Logging for Terraform State
+
+## Status
+Accepted
+
+## Context
+The bootstrap module created an encrypted S3 bucket to store Terraform state but did not record access to it. Capturing server access logs helps track any reads or writes to the state files.
+
+## Decision
+We introduced a separate bucket `eskimo-tf-logs` managed by the same S3 module. Logging is enabled on the state bucket with logs delivered to this new bucket. The log bucket is versioned, encrypted and allows log delivery from S3 only.
+
+## Consequences
+- Access to the Terraform state bucket is now auditable via standard S3 logs.
+- A small additional bucket must be managed and retained for compliance.

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -28,6 +28,29 @@ data "aws_iam_policy_document" "kms" {
   }
 }
 
+module "state_log_bucket" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=e1fb51bce8008b0d5fd660e81d97ff7a101bdbc6"
+
+  bucket                            = var.state_log_bucket_name
+  attach_access_log_delivery_policy = true
+
+  versioning = {
+    enabled = true
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  logging = {
+    target_bucket = var.state_log_bucket_name
+    target_prefix = "logs/"
+  }
+}
+
 
 module "state_bucket" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=e1fb51bce8008b0d5fd660e81d97ff7a101bdbc6"
@@ -44,6 +67,10 @@ module "state_bucket" {
         sse_algorithm = "AES256"
       }
     }
+  }
+  logging = {
+    target_bucket = module.state_log_bucket.s3_bucket_id
+    target_prefix = "state/"
   }
 }
 

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -21,3 +21,9 @@ variable "bootstrap_lock_table_name" {
   type        = string
   default     = "eskimo-bootstrap-tf-lock"
 }
+
+variable "state_log_bucket_name" {
+  description = "Name of S3 bucket to store state bucket access logs"
+  type        = string
+  default     = "eskimo-tf-logs"
+}


### PR DESCRIPTION
## Summary
- create `state_log_bucket` module to store state bucket access logs
- enable logging on `state_bucket`
- document new log bucket in runbook
- record design in ADR

## Testing
- `go test ./...`
- `go vet ./...`
- `govulncheck ./...`
- `terraform fmt -recursive`
- `tflint`
- `tfsec .`
- `checkov -d .`

------
https://chatgpt.com/codex/tasks/task_e_686aad6f482c833292dfae2bdf2ca8b6